### PR TITLE
feat: implement full frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+
 - Initial monorepo skeleton with frontend and backend scaffolds, docker setup, and documentation.
 - Backend API with JWT auth, user management, restaurants, menu items, seeding
   script, and migration utilities.
-
+- Full React frontend with auth, admin console, and restaurant & menu UI.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,18 +1,20 @@
 # Frontend
 
-Stub instructions for installing and running the React application.
+React frontend for LunchSync. Requires the backend API URL via `VITE_API_URL`.
 
 ## Development
 
 ```bash
 npm install
-npm run dev
+VITE_API_URL=http://localhost:3000 npm run dev
 ```
 
 ## Production
 
 ```bash
-npm run build
+VITE_API_URL=http://localhost:3000 npm run build
 npm run preview
 ```
 
+Routes are served through React Router. Authentication uses JWT stored in
+localStorage and role-based guards. Run `npm run lint` before committing.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,8 +9,16 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
+    "@tanstack/react-query": "^5.85.5",
+    "axios": "^1.11.0",
+    "jwt-decode": "^4.0.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-hook-form": "^7.62.0",
+    "react-hot-toast": "^2.6.0",
+    "react-router-dom": "^7.8.1",
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,36 @@
-import { useEffect, useState } from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import RequireAuth from './features/auth/RequireAuth';
+import RequireAdmin from './features/auth/RequireAdmin';
+import Login from './features/auth/Login';
+import Register from './features/auth/Register';
+import RestaurantsList from './features/restaurants/RestaurantsList';
+import RestaurantDetail from './features/restaurants/RestaurantDetail';
+import MenuItems from './features/menu/MenuItems';
+import UsersAdmin from './features/admin/UsersAdmin';
+import RestaurantsAdmin from './features/admin/RestaurantsAdmin';
+import MenuAdmin from './features/admin/MenuAdmin';
+import AppLayout from './layouts/AppLayout';
 
 function App() {
-  const [status, setStatus] = useState('loading');
-
-  useEffect(() => {
-    fetch(`${import.meta.env.VITE_API_URL}/health`)
-      .then((res) => res.json())
-      .then((data) => setStatus(data.status))
-      .catch(() => setStatus('error'));
-  }, []);
-
-  return <div className="p-4">Backend status: {status}</div>;
+  return (
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route path="/register" element={<Register />} />
+      <Route element={<RequireAuth />} path="/app">
+        <Route element={<AppLayout />}>
+          <Route path="restaurants" element={<RestaurantsList />} />
+          <Route path="restaurants/:id" element={<RestaurantDetail />} />
+          <Route path="restaurants/:id/menu" element={<MenuItems />} />
+          <Route element={<RequireAdmin />} path="admin">
+            <Route path="users" element={<UsersAdmin />} />
+            <Route path="restaurants" element={<RestaurantsAdmin />} />
+            <Route path="restaurants/:id/menu" element={<MenuAdmin />} />
+          </Route>
+        </Route>
+      </Route>
+      <Route path="*" element={<Navigate to="/login" replace />} />
+    </Routes>
+  );
 }
 
 export default App;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import { toast } from 'react-hot-toast';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL,
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (res) => res,
+  (error) => {
+    const status = error.response?.status;
+    if (status === 401) {
+      toast.error('Session expired');
+      window.location.href = '/login';
+    } else if (status === 403) {
+      toast.error('Forbidden');
+    } else {
+      toast.error('Server error');
+    }
+    return Promise.reject(error);
+  },
+);
+
+export default api;

--- a/frontend/src/features/admin/MenuAdmin.tsx
+++ b/frontend/src/features/admin/MenuAdmin.tsx
@@ -1,0 +1,130 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '../../api/client';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useParams } from 'react-router-dom';
+
+interface MenuItem {
+  _id: string;
+  name: string;
+  price: number;
+  category: string;
+}
+
+interface MenuItemPayload {
+  name: string;
+  price: number;
+  category: string;
+}
+
+const schema = z.object({
+  name: z.string().min(1),
+  price: z.number().positive(),
+  category: z.string().min(1),
+});
+
+export default function MenuAdmin() {
+  const { id } = useParams();
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: ['menu', id],
+    queryFn: async () => (await api.get(`/restaurants/${id}/menu-items`)).data,
+  });
+  const createMutation = useMutation({
+    mutationFn: (payload: MenuItemPayload) =>
+      api.post(`/restaurants/${id}/menu-items`, payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['menu', id] }),
+  });
+  const updateMutation = useMutation({
+    mutationFn: ({ mid, payload }: { mid: string; payload: MenuItemPayload }) =>
+      api.put(`/restaurants/${id}/menu-items/${mid}`, payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['menu', id] }),
+  });
+  const deleteMutation = useMutation({
+    mutationFn: (mid: string) =>
+      api.delete(`/restaurants/${id}/menu-items/${mid}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['menu', id] }),
+  });
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<{ name: string; price: number; category: string }>({
+    resolver: zodResolver(schema),
+  });
+  const onSubmit = handleSubmit(async (data) => {
+    await createMutation.mutateAsync(data);
+    reset();
+  });
+  if (isLoading) return <div>Loading...</div>;
+  return (
+    <div>
+      <h1 className="text-xl mb-4">Menu Items</h1>
+      <form onSubmit={onSubmit} className="space-y-2 mb-6">
+        <input
+          className="border p-2 w-full"
+          placeholder="Name"
+          {...register('name')}
+        />
+        {errors.name && (
+          <p className="text-red-500 text-sm">{errors.name.message}</p>
+        )}
+        <input
+          className="border p-2 w-full"
+          type="number"
+          step="0.01"
+          placeholder="Price"
+          {...register('price', { valueAsNumber: true })}
+        />
+        {errors.price && (
+          <p className="text-red-500 text-sm">{errors.price.message}</p>
+        )}
+        <input
+          className="border p-2 w-full"
+          placeholder="Category"
+          {...register('category')}
+        />
+        {errors.category && (
+          <p className="text-red-500 text-sm">{errors.category.message}</p>
+        )}
+        <button className="bg-blue-500 text-white px-4 py-2" type="submit">
+          Create
+        </button>
+      </form>
+      <div className="space-y-4">
+        {data?.map((m: MenuItem) => (
+          <div key={m._id} className="border p-2">
+            <div>
+              {m.name} - ${m.price.toFixed(2)} ({m.category})
+            </div>
+            <button
+              className="text-sm text-blue-600 mr-2"
+              onClick={() => {
+                const name = prompt('Name', m.name);
+                const price = Number(prompt('Price', String(m.price)));
+                const category = prompt('Category', m.category);
+                if (name && category && !isNaN(price))
+                  updateMutation.mutate({
+                    mid: m._id,
+                    payload: { name, price, category },
+                  });
+              }}
+            >
+              Edit
+            </button>
+            <button
+              className="text-sm text-red-600"
+              onClick={() => {
+                if (confirm('Delete item?')) deleteMutation.mutate(m._id);
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/admin/RestaurantsAdmin.tsx
+++ b/frontend/src/features/admin/RestaurantsAdmin.tsx
@@ -1,0 +1,119 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '../../api/client';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Link } from 'react-router-dom';
+
+interface Restaurant {
+  _id: string;
+  name: string;
+  description: string;
+}
+
+interface CreateRestaurant {
+  name: string;
+  description: string;
+}
+
+const schema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+});
+
+export default function RestaurantsAdmin() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: ['restaurants'],
+    queryFn: async () => (await api.get('/restaurants')).data,
+  });
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateRestaurant) =>
+      api.post('/restaurants', payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['restaurants'] }),
+  });
+  const updateMutation = useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: CreateRestaurant }) =>
+      api.put(`/restaurants/${id}`, payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['restaurants'] }),
+  });
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/restaurants/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['restaurants'] }),
+  });
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<{ name: string; description: string }>({
+    resolver: zodResolver(schema),
+  });
+  const onSubmit = handleSubmit(async (data) => {
+    await createMutation.mutateAsync(data);
+    reset();
+  });
+  if (isLoading) return <div>Loading...</div>;
+  return (
+    <div>
+      <h1 className="text-xl mb-4">Restaurants</h1>
+      <form onSubmit={onSubmit} className="space-y-2 mb-6">
+        <input
+          className="border p-2 w-full"
+          placeholder="Name"
+          {...register('name')}
+        />
+        {errors.name && (
+          <p className="text-red-500 text-sm">{errors.name.message}</p>
+        )}
+        <input
+          className="border p-2 w-full"
+          placeholder="Description"
+          {...register('description')}
+        />
+        {errors.description && (
+          <p className="text-red-500 text-sm">{errors.description.message}</p>
+        )}
+        <button className="bg-blue-500 text-white px-4 py-2" type="submit">
+          Create
+        </button>
+      </form>
+      <div className="space-y-4">
+        {data?.map((r: Restaurant) => (
+          <div key={r._id} className="border p-2">
+            <div className="font-bold">{r.name}</div>
+            <div className="mb-2">{r.description}</div>
+            <button
+              className="text-sm text-blue-600 mr-2"
+              onClick={() => {
+                const name = prompt('Name', r.name);
+                const description = prompt('Description', r.description);
+                if (name && description)
+                  updateMutation.mutate({
+                    id: r._id,
+                    payload: { name, description },
+                  });
+              }}
+            >
+              Edit
+            </button>
+            <Link
+              className="text-sm text-green-600 mr-2"
+              to={`/app/admin/restaurants/${r._id}/menu`}
+            >
+              Menu
+            </Link>
+            <button
+              className="text-sm text-red-600"
+              onClick={() => {
+                if (confirm('Delete restaurant?')) deleteMutation.mutate(r._id);
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/admin/UsersAdmin.tsx
+++ b/frontend/src/features/admin/UsersAdmin.tsx
@@ -1,0 +1,129 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '../../api/client';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+interface User {
+  _id: string;
+  email: string;
+  role: string;
+}
+
+interface CreateUser {
+  email: string;
+  password: string;
+  role: string;
+}
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+  role: z.string(),
+});
+
+export default function UsersAdmin() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: ['users'],
+    queryFn: async () => (await api.get('/users')).data,
+  });
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateUser) => api.post('/users', payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['users'] }),
+  });
+  const updateMutation = useMutation({
+    mutationFn: ({ id, role }: { id: string; role: string }) =>
+      api.put(`/users/${id}`, { role }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['users'] }),
+  });
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/users/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['users'] }),
+  });
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<{ email: string; password: string; role: string }>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    await createMutation.mutateAsync(data);
+    reset();
+  });
+
+  if (isLoading) return <div>Loading...</div>;
+  return (
+    <div>
+      <h1 className="text-xl mb-4">Users</h1>
+      <form onSubmit={onSubmit} className="space-y-2 mb-6">
+        <input
+          className="border p-2 w-full"
+          placeholder="Email"
+          {...register('email')}
+        />
+        {errors.email && (
+          <p className="text-red-500 text-sm">{errors.email.message}</p>
+        )}
+        <input
+          className="border p-2 w-full"
+          type="password"
+          placeholder="Password"
+          {...register('password')}
+        />
+        {errors.password && (
+          <p className="text-red-500 text-sm">{errors.password.message}</p>
+        )}
+        <select className="border p-2 w-full" {...register('role')}>
+          <option value="user">user</option>
+          <option value="admin">admin</option>
+        </select>
+        <button className="bg-blue-500 text-white px-4 py-2" type="submit">
+          Create
+        </button>
+      </form>
+      <table className="w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 text-left">Email</th>
+            <th className="p-2 text-left">Role</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {data?.map((u: User) => (
+            <tr key={u._id} className="border-t">
+              <td className="p-2">{u.email}</td>
+              <td className="p-2">
+                <select
+                  className="border p-1"
+                  value={u.role}
+                  onChange={(e) =>
+                    updateMutation.mutate({ id: u._id, role: e.target.value })
+                  }
+                >
+                  <option value="user">user</option>
+                  <option value="admin">admin</option>
+                </select>
+              </td>
+              <td className="p-2 text-right">
+                <button
+                  className="text-red-600"
+                  onClick={() => {
+                    if (confirm('Delete user?')) deleteMutation.mutate(u._id);
+                  }}
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/features/auth/AuthProvider.tsx
+++ b/frontend/src/features/auth/AuthProvider.tsx
@@ -1,0 +1,61 @@
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import jwtDecode from 'jwt-decode';
+
+interface User {
+  email: string;
+  role: string;
+}
+
+interface AuthContextType {
+  user: User | null;
+  token: string | null;
+  login: (token: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [token, setToken] = useState<string | null>(() =>
+    localStorage.getItem('token'),
+  );
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    if (token) {
+      try {
+        const decoded = jwtDecode<{ email: string; role: string }>(token);
+        setUser({ email: decoded.email, role: decoded.role });
+        localStorage.setItem('token', token);
+      } catch {
+        setUser(null);
+        setToken(null);
+        localStorage.removeItem('token');
+      }
+    } else {
+      setUser(null);
+      localStorage.removeItem('token');
+    }
+  }, [token]);
+
+  const login = (newToken: string) => setToken(newToken);
+  const logout = () => setToken(null);
+
+  return (
+    <AuthContext.Provider value={{ user, token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/frontend/src/features/auth/Login.tsx
+++ b/frontend/src/features/auth/Login.tsx
@@ -1,0 +1,71 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import api from '../../api/client';
+import axios from 'axios';
+import { useAuth } from './AuthProvider';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-hot-toast';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export default function Login() {
+  const navigate = useNavigate();
+  const { login } = useAuth();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<{ email: string; password: string }>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    try {
+      const res = await api.post('/auth/login', data);
+      login(res.data.access_token);
+      navigate('/app/restaurants');
+    } catch (e: unknown) {
+      if (axios.isAxiosError(e)) {
+        toast.error(e.response?.data?.message || 'Login failed');
+      } else {
+        toast.error('Login failed');
+      }
+    }
+  });
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <h1 className="text-xl mb-4">Login</h1>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div>
+          <input
+            className="border p-2 w-full"
+            placeholder="Email"
+            {...register('email')}
+          />
+          {errors.email && (
+            <p className="text-red-500 text-sm">{errors.email.message}</p>
+          )}
+        </div>
+        <div>
+          <input
+            className="border p-2 w-full"
+            type="password"
+            placeholder="Password"
+            {...register('password')}
+          />
+          {errors.password && (
+            <p className="text-red-500 text-sm">{errors.password.message}</p>
+          )}
+        </div>
+        <button className="bg-blue-500 text-white px-4 py-2" type="submit">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/features/auth/Register.tsx
+++ b/frontend/src/features/auth/Register.tsx
@@ -1,0 +1,69 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import api from '../../api/client';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import { toast } from 'react-hot-toast';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export default function Register() {
+  const navigate = useNavigate();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<{ email: string; password: string }>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    try {
+      await api.post('/auth/register', data);
+      toast.success('Registered, please log in');
+      navigate('/login');
+    } catch (e: unknown) {
+      if (axios.isAxiosError(e)) {
+        toast.error(e.response?.data?.message || 'Registration failed');
+      } else {
+        toast.error('Registration failed');
+      }
+    }
+  });
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <h1 className="text-xl mb-4">Register</h1>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div>
+          <input
+            className="border p-2 w-full"
+            placeholder="Email"
+            {...register('email')}
+          />
+          {errors.email && (
+            <p className="text-red-500 text-sm">{errors.email.message}</p>
+          )}
+        </div>
+        <div>
+          <input
+            className="border p-2 w-full"
+            type="password"
+            placeholder="Password"
+            {...register('password')}
+          />
+          {errors.password && (
+            <p className="text-red-500 text-sm">{errors.password.message}</p>
+          )}
+        </div>
+        <button className="bg-blue-500 text-white px-4 py-2" type="submit">
+          Register
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/features/auth/RequireAdmin.tsx
+++ b/frontend/src/features/auth/RequireAdmin.tsx
@@ -1,0 +1,9 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from './AuthProvider';
+
+export default function RequireAdmin() {
+  const { user } = useAuth();
+  if (!user) return <Navigate to="/login" replace />;
+  if (user.role !== 'admin') return <div className="p-4">Forbidden</div>;
+  return <Outlet />;
+}

--- a/frontend/src/features/auth/RequireAuth.tsx
+++ b/frontend/src/features/auth/RequireAuth.tsx
@@ -1,0 +1,8 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from './AuthProvider';
+
+export default function RequireAuth() {
+  const { user } = useAuth();
+  if (!user) return <Navigate to="/login" replace />;
+  return <Outlet />;
+}

--- a/frontend/src/features/menu/MenuItems.tsx
+++ b/frontend/src/features/menu/MenuItems.tsx
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../../api/client';
+import { useParams } from 'react-router-dom';
+
+interface MenuItem {
+  _id: string;
+  name: string;
+  price: number;
+  category: string;
+}
+
+export default function MenuItems() {
+  const { id } = useParams();
+  const { data, isLoading } = useQuery({
+    queryKey: ['menu', id],
+    queryFn: async () => (await api.get(`/restaurants/${id}/menu-items`)).data,
+  });
+  if (isLoading) return <div>Loading...</div>;
+  if (!data?.length) return <div>No items</div>;
+  const groups: Record<string, MenuItem[]> = {};
+  data.forEach((item: MenuItem) => {
+    groups[item.category] = groups[item.category] || [];
+    groups[item.category].push(item);
+  });
+  return (
+    <div>
+      {Object.entries(groups).map(([cat, items]) => (
+        <div key={cat} className="mb-4">
+          <h2 className="text-lg">{cat}</h2>
+          <ul className="pl-4 list-disc">
+            {items.map((i) => (
+              <li key={i._id}>
+                {i.name} - ${i.price.toFixed(2)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/restaurants/RestaurantDetail.tsx
+++ b/frontend/src/features/restaurants/RestaurantDetail.tsx
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../../api/client';
+import { Link, useParams } from 'react-router-dom';
+
+export default function RestaurantDetail() {
+  const { id } = useParams();
+  const { data, isLoading } = useQuery({
+    queryKey: ['restaurant', id],
+    queryFn: async () => (await api.get(`/restaurants/${id}`)).data,
+  });
+  if (isLoading) return <div>Loading...</div>;
+  if (!data) return <div>Not found</div>;
+  return (
+    <div>
+      <h1 className="text-xl mb-2">{data.name}</h1>
+      <p className="mb-4">{data.description}</p>
+      <Link className="underline" to={`/app/restaurants/${id}/menu`}>
+        View Menu
+      </Link>
+    </div>
+  );
+}

--- a/frontend/src/features/restaurants/RestaurantsList.tsx
+++ b/frontend/src/features/restaurants/RestaurantsList.tsx
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../../api/client';
+import { Link } from 'react-router-dom';
+
+interface Restaurant {
+  _id: string;
+  name: string;
+}
+
+export default function RestaurantsList() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['restaurants'],
+    queryFn: async () => (await api.get('/restaurants')).data,
+  });
+
+  if (isLoading) return <div>Loading...</div>;
+  return (
+    <div className="space-y-2">
+      {data?.map((r: Restaurant) => (
+        <div key={r._id} className="border p-2">
+          <Link className="underline" to={`/app/restaurants/${r._id}`}>
+            {r.name}
+          </Link>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,0 +1,23 @@
+import { Link, Outlet } from 'react-router-dom';
+import { useAuth } from '../features/auth/AuthProvider';
+
+export default function AppLayout() {
+  const { user, logout } = useAuth();
+  return (
+    <div>
+      <nav className="bg-gray-800 text-white p-4 flex gap-4">
+        <Link to="/app/restaurants">Restaurants</Link>
+        {user?.role === 'admin' && <Link to="/app/admin/users">Admin</Link>}
+        <span className="flex-1" />
+        {user && (
+          <button onClick={logout} className="underline">
+            Logout
+          </button>
+        )}
+      </nav>
+      <main className="p-4">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
 import './index.css';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Toaster } from 'react-hot-toast';
+import { AuthProvider } from './features/auth/AuthProvider';
+import App from './App';
+
+const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <BrowserRouter>
+          <Toaster />
+          <App />
+        </BrowserRouter>
+      </AuthProvider>
+    </QueryClientProvider>
+  </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- build React/Vite frontend with auth, restaurant browsing, and admin console
- add role-based routing and API client with token interceptors
- document frontend usage and configuration

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6f7a7a4608325a49f2cce1111a5ef